### PR TITLE
Added return call to fix Static Analyzer issue

### DIFF
--- a/ALAssetsLibrary-CustomPhotoAlbum/ALAssetsLibrary+CustomPhotoAlbum.m
+++ b/ALAssetsLibrary-CustomPhotoAlbum/ALAssetsLibrary+CustomPhotoAlbum.m
@@ -288,7 +288,10 @@
 {
   ALAssetsLibraryGroupsEnumerationResultsBlock block = ^(ALAssetsGroup *group, BOOL *stop) {
     // Checking if library exists
-    if (group == nil) *stop = YES;
+    if (group == nil) {
+      *stop = YES;
+      return;
+    }
     
     // If we have found library with given title we enumerate it
     if ([albumName compare:[group valueForProperty:ALAssetsGroupPropertyName]] == NSOrderedSame) {


### PR DESCRIPTION
Without the return, the Static Analyzer raises an "Argment to 'NSString'
method 'compare:' cannot be nil" issue.   (Using Xcode 6.1.1)

This fixes issue #22 