### PR TITLE
Fix issue with nil failure handler

### DIFF
--- a/ALAssetsLibrary-CustomPhotoAlbum/ALAssetsLibrary+CustomPhotoAlbum.m
+++ b/ALAssetsLibrary-CustomPhotoAlbum/ALAssetsLibrary+CustomPhotoAlbum.m
@@ -85,9 +85,9 @@
     //   or if the asset could not be added to the group.
     else {
       NSString * message = [NSString stringWithFormat:@"ALAssetsGroup failed to add asset: %@.", asset];
-      failure([NSError errorWithDomain:@"LIB_ALAssetsLibrary_CustomPhotoAlbum"
-                                  code:0
-                              userInfo:@{NSLocalizedDescriptionKey : message}]);
+      if (failure) failure([NSError errorWithDomain:@"LIB_ALAssetsLibrary_CustomPhotoAlbum"
+                                               code:0
+                                           userInfo:@{NSLocalizedDescriptionKey : message}]);
     }
   };
 }


### PR DESCRIPTION
`_assetForURLResultBlockWithGroup` has an issue where it does not check if the failure handler is non-nil before executing it (like it does with the success handler). 