### PR TITLE
Crash Resolved : After Capturing a photo for the first time.

### DIFF
--- a/Demo/ALAssetsLibraryCustomPhotoAlbum_BasicDemo/ALAssetsLibraryCustomPhotoAlbum_BasicDemo/Controllers/PhotosTableViewController.m
+++ b/Demo/ALAssetsLibraryCustomPhotoAlbum_BasicDemo/ALAssetsLibraryCustomPhotoAlbum_BasicDemo/Controllers/PhotosTableViewController.m
@@ -99,6 +99,14 @@
   return assetsLibrary_;
 }
 
+-(NSMutableArray *)photoURLs
+{
+    if(!photoURLs_) {
+        photoURLs_ = [[NSMutableArray alloc] init];
+    }
+    return photoURLs_;
+}
+
 #pragma mark - Table view data source
 
 // Return the number of sections.


### PR DESCRIPTION
Application was crashing after capturing a photo for the first time. Added a getter method in this commit. Please merge this to the code to stop the crash in the app.